### PR TITLE
feat: Add AES decryption support with IV handling

### DIFF
--- a/android/src/main/kotlin/id/my/burganbank/flutter_shield/EncryptionStrategy.kt
+++ b/android/src/main/kotlin/id/my/burganbank/flutter_shield/EncryptionStrategy.kt
@@ -42,4 +42,7 @@ interface EncryptionStrategy {
 
     @Throws(Exception::class)
     fun verify(tag: String, plainText: String, signature: String): Boolean
+
+    @Throws(Exception::class)
+    fun decryptWithAES(encryptedData: ByteArray, aesKey: ByteArray): String?
 }

--- a/android/src/main/kotlin/id/my/burganbank/flutter_shield/LegacyEncryptionStrategy.kt
+++ b/android/src/main/kotlin/id/my/burganbank/flutter_shield/LegacyEncryptionStrategy.kt
@@ -15,6 +15,8 @@ import java.security.KeyStore.*
 import java.security.spec.ECGenParameterSpec
 import java.security.spec.PKCS8EncodedKeySpec
 import javax.crypto.Cipher
+import javax.crypto.spec.SecretKeySpec
+import javax.crypto.spec.IvParameterSpec
 
 class LegacyEncryptionStrategy(private val context: Context) : EncryptionStrategy {
 
@@ -210,7 +212,9 @@ class LegacyEncryptionStrategy(private val context: Context) : EncryptionStrateg
         val privateKey = getServerPrivateKey(tag) ?: return null
         val cipher = Cipher.getInstance("RSA/ECB/OAEPWithSHA-256AndMGF1Padding") //RSA/ECB/PKCS1Padding
         cipher.init(Cipher.DECRYPT_MODE, privateKey)
-        return String(cipher.doFinal(message))
+        val decryptedBytes = cipher.doFinal(message)
+        // Server returns raw AES key bytes, convert to base64 for consistent handling
+        return Base64.encodeToString(decryptedBytes, Base64.NO_WRAP)
     }
 
     override fun sign(tag: String, message: ByteArray): String? {
@@ -233,5 +237,32 @@ class LegacyEncryptionStrategy(private val context: Context) : EncryptionStrateg
         signatureInstance.initVerify(publicKey)
         signatureInstance.update(plainText.toByteArray())
         return signatureInstance.verify(Base64.decode(signature, Base64.NO_WRAP))
+    }
+
+    override fun decryptWithAES(encryptedData: ByteArray, aesKey: ByteArray): String? {
+        return try {
+            // Server updated: IV is now prepended to encrypted data
+            // Format: [IV (16 bytes)][Encrypted Data (remaining bytes)]
+            
+            if (encryptedData.size < 16) {
+                throw IllegalArgumentException("Encrypted data too short - must contain at least 16 bytes for IV")
+            }
+            
+            val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+            val secretKeySpec = SecretKeySpec(aesKey, "AES")
+            
+            // Extract IV from first 16 bytes
+            val iv = encryptedData.sliceArray(0..15)
+            val actualEncryptedData = encryptedData.sliceArray(16 until encryptedData.size)
+            
+            val ivParameterSpec = IvParameterSpec(iv)
+            cipher.init(Cipher.DECRYPT_MODE, secretKeySpec, ivParameterSpec)
+            
+            val decryptedData = cipher.doFinal(actualEncryptedData)
+            String(decryptedData, Charsets.UTF_8)
+        } catch (e: Exception) {
+            e.printStackTrace()
+            null
+        }
     }
 }

--- a/android/src/main/kotlin/id/my/burganbank/flutter_shield/SecureEnclavePlugin.kt
+++ b/android/src/main/kotlin/id/my/burganbank/flutter_shield/SecureEnclavePlugin.kt
@@ -189,6 +189,17 @@ class SecureEnclavePlugin: FlutterPlugin, MethodCallHandler {
                     result.error("ERROR", e.localizedMessage, null)
                 }
             }
+            "decryptWithAES" -> {
+                try {
+                    val param = call.arguments as? Map<String, Any>
+                    val encryptedData = (param?.get("encryptedData") as? ByteArray) ?: byteArrayOf()
+                    val aesKey = (param?.get("aesKey") as? ByteArray) ?: byteArrayOf()
+                    val decrypted = encryptionStrategy.decryptWithAES(encryptedData, aesKey)
+                    result.success(mapOf("status" to "success", "data" to decrypted))
+                } catch (e: Exception) {
+                    result.error("ERROR", e.localizedMessage, null)
+                }
+            }
             else -> {
                 result.notImplemented()
             }

--- a/example/README.md
+++ b/example/README.md
@@ -1,3 +1,214 @@
 # FLUTTER SHIELD EXAMPLE
 
 Demonstrates how to use the flutter_shield plugin.
+
+## 🚀 Build & Run Instructions
+
+### Prerequisites
+
+Before running the example app, ensure you have:
+
+- Flutter SDK installed (`flutter doctor` should pass)
+- iOS development tools (Xcode for iOS/macOS)
+- Android development tools (Android Studio for Android)
+- Connected device or running simulator
+
+### 1. Check Prerequisites
+
+```bash
+flutter doctor
+```
+
+If Android licenses are not accepted, run:
+```bash
+flutter doctor --android-licenses
+```
+
+### 2. Install Dependencies
+
+Navigate to the example directory and install dependencies:
+
+```bash
+cd example
+flutter pub get
+```
+
+### 3. Check Available Devices
+
+```bash
+flutter devices
+```
+
+### 4. Launch Emulators (Optional)
+
+#### iOS Simulator
+```bash
+flutter emulators --launch apple_ios_simulator
+```
+
+#### Android Emulator
+```bash
+flutter emulators --launch Medium_Phone_API_35
+```
+
+### 5. Run the Example App
+
+#### Option A: Run on Default Device
+```bash
+flutter run
+```
+
+#### Option B: Run on Specific Device
+```bash
+# iOS Physical Device
+flutter run -d "00008130-000A10603AA0001C"
+
+# iOS Simulator
+flutter run -d "314D4D27-A97B-4182-96A7-B87D1156ECDD"
+
+# macOS Desktop
+flutter run -d macos
+
+# Android Emulator
+flutter run -d Medium_Phone_API_35
+
+# Chrome Web
+flutter run -d chrome
+```
+
+#### Option C: Using VS Code
+1. Open the project in VS Code:
+   ```bash
+   code .
+   ```
+2. Select target device from the bottom status bar
+3. Press `F5` or use "Run and Debug" panel
+
+#### Option D: Using Xcode (iOS only)
+1. Open iOS project in Xcode:
+   ```bash
+   open ios/Runner.xcworkspace
+   ```
+2. Select target device/simulator
+3. Click the Run button
+
+### 6. Test the SDK Features
+
+Once the app is running, you can test various features:
+
+#### 🔑 Generate Certificate
+- Tap "Generate Cert" to create key pairs and certificates
+- Test with different access control options
+
+#### 🔐 AES Decrypt Test (New Feature)
+- Tap "AES Decrypt Test" to test the new AES decryption functionality
+- Use the pre-filled sample data or input your own encrypted JSON
+- Test the complete flow: RSA decrypt → AES decrypt
+
+#### ✍️ Signature & Verify
+- Test digital signing and verification
+- Generate signatures and verify them
+
+#### 🌐 MTLS Call
+- Test mutual TLS authentication
+- Verify certificate-based communication
+
+#### 🔒 Password Testing
+- Test secure password storage and retrieval
+
+## 🔧 Development Commands
+
+### Hot Reload
+While the app is running, press `r` in the terminal to hot reload.
+
+### Hot Restart
+Press `R` to hot restart the application.
+
+### Clean Build
+```bash
+flutter clean
+flutter pub get
+flutter run
+```
+
+### Debug Mode vs Release Mode
+```bash
+# Debug mode (default)
+flutter run
+
+# Release mode
+flutter run --release
+
+# Profile mode
+flutter run --profile
+```
+
+## 📱 Platform Support
+
+- ✅ **iOS**: Full Secure Enclave support with biometric authentication
+- ✅ **Android**: Hardware Security Module (HSM) support
+- ✅ **macOS**: Desktop security features
+- ⚠️ **Web**: Limited functionality (fallback implementations)
+
+## 🧪 Testing AES Decryption
+
+The example app includes a comprehensive test for the new AES decryption feature:
+
+1. **Navigate to "AES Decrypt Test"**
+2. **Input Format**: The app expects a JSON response from your server:
+   ```json
+   {
+     "transactionId": "uuid-here",
+     "encryptedKey": "base64-encoded-rsa-encrypted-aes-key",
+     "encryptData": "base64-encoded-aes-encrypted-payload"
+   }
+   ```
+3. **Test Flow**:
+   - RSA decrypt the `encryptedKey` to get AES key
+   - AES decrypt the `encryptData` using the retrieved key
+   - Display the decrypted payload
+
+## 🐛 Troubleshooting
+
+### Common Issues
+
+1. **Build Errors**:
+   ```bash
+   flutter clean
+   flutter pub get
+   ```
+
+2. **iOS Simulator Issues**:
+   - Ensure Xcode is properly installed
+   - Try restarting the simulator
+
+3. **Android License Issues**:
+   ```bash
+   flutter doctor --android-licenses
+   ```
+
+4. **Device Not Found**:
+   ```bash
+   flutter devices
+   flutter emulators
+   ```
+
+### Platform-Specific Issues
+
+#### iOS
+- Ensure your Apple Developer account is set up
+- Check code signing settings in Xcode
+- Verify device is trusted for development
+
+#### Android
+- Ensure USB debugging is enabled
+- Check Android SDK installation
+- Verify emulator has enough storage
+
+## 📚 API Documentation
+
+For detailed API documentation, see the main [Flutter Shield README](../README.md).
+
+## 🤝 Contributing
+
+Found a bug or want to contribute? Please check the main repository for contribution guidelines.

--- a/example/lib/aes_decrypt_test.dart
+++ b/example/lib/aes_decrypt_test.dart
@@ -1,0 +1,264 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_shield/secure_enclave.dart';
+import 'package:flutter_shield_example/DeviceInfoProvider.dart';
+import 'package:provider/provider.dart';
+
+class AESDecryptTest extends StatefulWidget {
+  const AESDecryptTest({Key? key}) : super(key: key);
+
+  @override
+  State<AESDecryptTest> createState() => _AESDecryptTestState();
+}
+
+class _AESDecryptTestState extends State<AESDecryptTest> {
+  final TextEditingController _encryptedKeyController = TextEditingController();
+  final TextEditingController _encryptedDataController = TextEditingController();
+  
+  String _decryptedResult = '';
+  bool _isLoading = false;
+  
+  @override
+  void initState() {
+    super.initState();
+    // Örnek veriler
+    _encryptedKeyController.text = '''
+{
+  "transactionId": "fca8b941-535b-41f6-b8e1-7d53196c5651",
+  "encryptedKey": "ZLMek7BYRNuZCTeF4Mp/jW/ANRCiAeQk4DC0rPhDjkcrQ9nGbipM6M65gXkJVmgfN+zqVuaWa5pF2xc1igJ2VgbIh6ur1ifG8BGxZAIKAW2flO0Qmi/c/TWaDloC7zPiuD1PFzUxrFc8VygxrxvKx8vAJb+opv6KSmdhTMW+tKtZasU6pe34zswILUdNOa8jIvOrmwVWTs/emJoLxT3ux/22DV/ra1trjZB5xksCm9Qe8yFc3bZPl3jsRJSTNhW2dX9iUCTikI94eex/Xx66MqSYWo/GtR/rldeK4I0hrO/TK/UIooRBhxRKnjZpsBoYDzQrwl45ou7qq6O1TEHxBA==",
+  "encryptData": "YSYGXsKaxG9BdTO/OMEYB5R4JRaa+GmTgzCMMhAhqolX47ACx6CV8CWymURGtHLwmg4HEG6GIFr5lF2h5CLhACimyhuZc/NsAn4KoO1VDoCOrrbbbCIOKPE4N8LkugUJD3nLCSpEUEoODksKDW/C3S7esDzROtdPXdJzjO9MufesG43FW11lsVeAOr0QeWKW5bSTMrFFIbjEIIFUWp2MPjAmqWzqq8iTuQJ5y7UbOG06hqtHM6CQNwI0taMeP1P9Pzkv2VwI4pYsrQhBpA/ClPjAKZHoavRb8eOaATEjJmIVnYiSSd0Rf6P7L3duj0XMZiKx97TWfYZHSRKoYV1rjd7IpF5ik0DT1fLtNmWGjlRh6WkMI3c28hBSAg6wCxVk2/BV8BNenkX4GOMrEWtgz0/KnCpR5Fjsaj5w9kC/vi+mpkn+YBYfUxxGY8c+khvHzjfAkbrw1GALpn+voQUaASsdhDmR7UVNe03Y1BGznY+a/L83TsEYJqsxxnfPlljBA2aWfR9dDQPRzYbuWbsReQqU6XK63zLV+LYOc39E3chEfVgAqQORT0ciCQshqY36kOShpTQ7keOjK7kxIiHeoyaRCdTQv6aLRT5aFwx8n8yy3olbNSCmwHTwUfQZdIkSu1z0OjUbGatFrp87tHOotit9ekRol3jhCuCt3miahvk4y3MYroeWXOvwj2k41fnUrELrQkw/IM/20R2IsIWYgQ=="
+}
+''';
+  }
+
+  Future<void> _testAESDecrypt() async {
+    final deviceInfoProvider = Provider.of<DeviceInfoProvider>(context, listen: false);
+    final tag = deviceInfoProvider.clientKey;
+    
+    if (tag.isEmpty) {
+      setState(() {
+        _decryptedResult = 'Error: Tag is empty. Please generate a certificate first.';
+        _isLoading = false;
+      });
+      return;
+    }
+    
+    setState(() {
+      _isLoading = true;
+      _decryptedResult = 'Starting AES decrypt test...\nUsing tag: $tag';
+    });
+
+    try {
+      // Check if server key exists for this tag
+      final serverKeyResult = await SecureEnclave().getServerKey(tag: tag);
+      
+      setState(() {
+        _decryptedResult += '\n\nChecking server key...';
+        _decryptedResult += '\nServer key exists: ${serverKeyResult.error == null && serverKeyResult.value != null}';
+        if (serverKeyResult.error != null) {
+          _decryptedResult += '\nServer key error: ${serverKeyResult.error!.desc}';
+        }
+      });
+      
+      if (serverKeyResult.error != null || serverKeyResult.value == null) {
+        setState(() {
+          _decryptedResult += '\n\n❌ ERROR: No server private key found for tag "$tag".\n\nPlease go to "Generate Cert" and create a certificate first.';
+          _isLoading = false;
+        });
+        return;
+      }
+
+      // Parse JSON input
+      final jsonData = json.decode(_encryptedKeyController.text) as Map<String, dynamic>;
+      final encryptedKey = jsonData['encryptedKey'] as String;
+      final encryptedData = jsonData['encryptData'] as String;
+      
+      setState(() {
+        _decryptedResult += '\n\nParsing JSON... ✅';
+        _decryptedResult += '\nEncrypted key length: ${encryptedKey.length}';
+        _decryptedResult += '\nEncrypted data length: ${encryptedData.length}';
+      });
+      
+      // Step 1: Decrypt the AES key using RSA (existing method)
+      final encryptedKeyBytes = base64.decode(encryptedKey);
+      
+      setState(() {
+        _decryptedResult += '\n\nStarting RSA decrypt...';
+        _decryptedResult += '\nEncrypted key bytes: ${encryptedKeyBytes.length}';
+      });
+      
+      final rsaDecryptResult = await SecureEnclave().decrypt(
+        tag: tag,
+        message: Uint8List.fromList(encryptedKeyBytes),
+      );
+
+      if (rsaDecryptResult.error != null || rsaDecryptResult.value == null) {
+        setState(() {
+          _decryptedResult += '\n\n❌ RSA Decrypt Failed!';
+          _decryptedResult += '\nError: ${rsaDecryptResult.error?.desc ?? "Unknown error"}';
+          _decryptedResult += '\n\n💡 Possible solutions:';
+          _decryptedResult += '\n1. Generate a new certificate in "Generate Cert"';
+          _decryptedResult += '\n2. Use real encrypted data from your server';
+          _decryptedResult += '\n3. This sample data might not match your private key';
+          _isLoading = false;
+        });
+        return;
+      }
+
+      setState(() {
+        _decryptedResult += '\n\n✅ RSA Decrypt Success!';
+      });
+
+      // The decrypted AES key is now base64 encoded by our decrypt method
+      final aesKeyString = rsaDecryptResult.value!;
+      final aesKeyBytes = base64.decode(aesKeyString);
+
+      setState(() {
+        _decryptedResult += '\nAES Key length: ${aesKeyBytes.length} bytes';
+        _decryptedResult += '\nAES Key (base64): ${aesKeyString.substring(0, 20)}...';
+        _decryptedResult += '\n\n🔍 Starting AES decrypt with optimized logic...';
+        _decryptedResult += '\n• Server updated: IV + encrypted data format';
+        _decryptedResult += '\n• Expected format: [IV 16 bytes][Encrypted Data]';
+      });
+
+      // Step 2: Decrypt the payload using AES
+      final encryptedDataBytes = base64.decode(encryptedData);
+      
+      setState(() {
+        _decryptedResult += '\nEncrypted data bytes length: ${encryptedDataBytes.length}';
+        _decryptedResult += '\nFirst 16 bytes (IV hex): ${encryptedDataBytes.take(16).map((b) => b.toRadixString(16).padLeft(2, '0')).join(' ')}';
+        _decryptedResult += '\nNext 16 bytes (data hex): ${encryptedDataBytes.skip(16).take(16).map((b) => b.toRadixString(16).padLeft(2, '0')).join(' ')}';
+      });
+      
+      final aesDecryptResult = await SecureEnclave().decryptWithAES(
+        encryptedData: Uint8List.fromList(encryptedDataBytes),
+        aesKey: Uint8List.fromList(aesKeyBytes),
+      );
+
+      if (aesDecryptResult.error == null && aesDecryptResult.value != null) {
+        final decryptedText = aesDecryptResult.value!;
+        setState(() {
+          _decryptedResult += '\n\n✅ AES Decrypt Success!';
+          _decryptedResult += '\n🔓 IV Successfully Extracted and Used';
+          _decryptedResult += '\nDecrypted length: ${decryptedText.length} characters';
+          _decryptedResult += '\nFirst 50 chars: ${decryptedText.length > 50 ? decryptedText.substring(0, 50) + '...' : decryptedText}';
+          _decryptedResult += '\n\n🎉 COMPLETE SUCCESS!';
+          _decryptedResult += '\n\n📋 Results:';
+          _decryptedResult += '\n• Used Tag: $tag';
+          _decryptedResult += '\n• IV + Data Format: Confirmed ✅';
+          _decryptedResult += '\n• Decrypted AES Key: ${aesKeyString.substring(0, 20)}...';
+          _decryptedResult += '\n\n• Full Decrypted Payload:';
+          _decryptedResult += '\n${decryptedText}';
+        });
+      } else {
+        setState(() {
+          _decryptedResult += '\n\n❌ AES Decrypt Failed!';
+          _decryptedResult += '\nError: ${aesDecryptResult.error?.desc ?? "Unknown error"}';
+        });
+      }
+    } catch (e) {
+      setState(() {
+        _decryptedResult += '\n\n💥 Exception caught: $e';
+      });
+    } finally {
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('AES Decrypt Test'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            // Display current tag from DeviceInfoProvider
+            Consumer<DeviceInfoProvider>(
+              builder: (context, deviceInfoProvider, child) {
+                return Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: Colors.blue.shade50,
+                    border: Border.all(color: Colors.blue.shade200),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text(
+                        'Current Tag:',
+                        style: TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        deviceInfoProvider.tag.isEmpty 
+                          ? 'No tag available. Generate certificate first.' 
+                          : deviceInfoProvider.tag,
+                        style: TextStyle(
+                          fontFamily: 'monospace',
+                          color: deviceInfoProvider.tag.isEmpty 
+                            ? Colors.red 
+                            : Colors.green.shade700,
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: TextField(
+                controller: _encryptedKeyController,
+                decoration: const InputDecoration(
+                  labelText: 'Encrypted JSON Response',
+                  border: OutlineInputBorder(),
+                ),
+                maxLines: null,
+                expands: true,
+              ),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _isLoading ? null : _testAESDecrypt,
+              child: _isLoading 
+                ? const CircularProgressIndicator()
+                : const Text('Decrypt AES Data'),
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  border: Border.all(color: Colors.grey),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: SingleChildScrollView(
+                  child: Text(
+                    _decryptedResult.isEmpty ? 'Result will appear here...' : _decryptedResult,
+                    style: const TextStyle(fontFamily: 'monospace'),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _encryptedKeyController.dispose();
+    _encryptedDataController.dispose();
+    super.dispose();
+  }
+}

--- a/example/lib/dashboard.dart
+++ b/example/lib/dashboard.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_shield_example/aes_decrypt_test.dart';
 import 'package:flutter_shield_example/app_mtls.dart';
 import 'package:flutter_shield_example/app_password.dart';
 import 'package:flutter_shield_example/generate_cert.dart';
@@ -102,6 +103,28 @@ class _DashboardState extends State<Dashboard> {
                     height: 100,
                     child: Center(
                       child: Text('MTLS Call'),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            Card(
+              child: InkWell(
+                borderRadius: BorderRadius.circular(5),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => const AESDecryptTest(),
+                    ),
+                  );
+                },
+                child: const Padding(
+                  padding: EdgeInsets.all(8.0),
+                  child: SizedBox(
+                    height: 100,
+                    child: Center(
+                      child: Text('AES Decrypt Test'),
                     ),
                   ),
                 ),

--- a/ios/Classes/EncryptionStrategy.swift
+++ b/ios/Classes/EncryptionStrategy.swift
@@ -29,4 +29,6 @@ protocol EncryptionStrategy {
     func sign(tag: String, message: Data) throws -> String?
     
     func verify(tag: String, plainText: String, signature: String) throws -> Bool
+    
+    func decryptWithAES(encryptedData: Data, aesKey: Data) throws -> String?
 }

--- a/ios/Classes/ModernEncryptionStrategy.swift
+++ b/ios/Classes/ModernEncryptionStrategy.swift
@@ -1,5 +1,6 @@
 import Foundation
 import LocalAuthentication
+import CommonCrypto
 
 @available(iOS 11.3, *)
 class ModernEncryptionStrategy : EncryptionStrategy {
@@ -205,7 +206,7 @@ class ModernEncryptionStrategy : EncryptionStrategy {
         }
         
         if let secAttrApplicationTag = secAttrApplicationTag {
-            if TARGET_OS_SIMULATOR != 0 {
+            #if targetEnvironment(simulator)
                 // target is current running in the simulator
                 parameterTemp = [
                     kSecAttrKeyType as String           : kSecAttrKeyTypeEC, //kSecAttrKeyTypeEC,
@@ -216,7 +217,7 @@ class ModernEncryptionStrategy : EncryptionStrategy {
                         kSecAttrAccessControl as String     : secAttrAccessControl!
                     ]
                 ]
-            } else {
+            #else
                 parameterTemp = [
                     kSecAttrKeyType as String           : kSecAttrKeyTypeEC,
                     kSecAttrKeySizeInBits as String     : 256,
@@ -227,7 +228,7 @@ class ModernEncryptionStrategy : EncryptionStrategy {
                         kSecAttrAccessControl as String     : secAttrAccessControl!
                     ]
                 ]
-            }
+            #endif
             
             // convert ke CFDictinery,0
             parameter = parameterTemp as CFDictionary
@@ -408,8 +409,9 @@ class ModernEncryptionStrategy : EncryptionStrategy {
         }
         
         if let plainTextData = plainTextData {
-            let plainText = String(decoding: plainTextData, as: UTF8.self)
-            return plainText
+            // Server returns raw AES key bytes, convert to base64 for consistent handling
+            let base64Key = plainTextData.base64EncodedString()
+            return base64Key
         } else {
             throw CustomError.runtimeError("Can't decrypt data")
         }
@@ -476,5 +478,44 @@ class ModernEncryptionStrategy : EncryptionStrategy {
                 nil
             )
         return verifyRes;
+    }
+    
+    func decryptWithAES(encryptedData: Data, aesKey: Data) throws -> String? {
+        // Server updated: IV is now prepended to encrypted data
+        // Format: [IV (16 bytes)][Encrypted Data (remaining bytes)]
+        
+        guard encryptedData.count > kCCBlockSizeAES128 else {
+            throw CustomError.runtimeError("Encrypted data too short - must contain at least 16 bytes for IV")
+        }
+        
+        // Extract IV from first 16 bytes
+        let iv = encryptedData.prefix(kCCBlockSizeAES128)
+        let actualEncryptedData = encryptedData.dropFirst(kCCBlockSizeAES128)
+        
+        // Create output buffer
+        let bufferSize = actualEncryptedData.count + kCCBlockSizeAES128
+        var buffer = [UInt8](repeating: 0, count: bufferSize)
+        var numBytesDecrypted: size_t = 0
+        
+        let status = CCCrypt(
+            CCOperation(kCCDecrypt),
+            CCAlgorithm(kCCAlgorithmAES),
+            CCOptions(kCCOptionPKCS7Padding),
+            aesKey.withUnsafeBytes { $0.bindMemory(to: UInt8.self).baseAddress },
+            aesKey.count,
+            iv.withUnsafeBytes { $0.bindMemory(to: UInt8.self).baseAddress },
+            actualEncryptedData.withUnsafeBytes { $0.bindMemory(to: UInt8.self).baseAddress },
+            actualEncryptedData.count,
+            &buffer,
+            bufferSize,
+            &numBytesDecrypted
+        )
+        
+        guard status == kCCSuccess else {
+            throw CustomError.runtimeError("AES decryption failed with status: \(status)")
+        }
+        
+        let decryptedData = Data(bytes: buffer, count: numBytesDecrypted)
+        return String(data: decryptedData, encoding: .utf8)
     }
 }

--- a/ios/Classes/SwiftSecureEnclavePlugin.swift
+++ b/ios/Classes/SwiftSecureEnclavePlugin.swift
@@ -155,6 +155,17 @@ public class SwiftSecureEnclavePlugin: NSObject, FlutterPlugin {
             } catch {
                 result(resultError(error:error))
             }
+            
+        case "decryptWithAES" :
+            do{
+                let param = call.arguments as? Dictionary<String, Any>
+                let encryptedData = param!["encryptedData"] as! FlutterStandardTypedData
+                let aesKey = param!["aesKey"] as! FlutterStandardTypedData
+                let decrypted = try encryptionStrategy.decryptWithAES(encryptedData: encryptedData.data, aesKey: aesKey.data)
+                result(resultSuccess(data:decrypted))
+            } catch {
+                result(resultError(error:error))
+            }
        
         default:
             return

--- a/lib/secure_enclave.dart
+++ b/lib/secure_enclave.dart
@@ -108,4 +108,15 @@ class SecureEnclave implements SecureEnclaveBase {
   Future<ResultModel<bool>> storeCertificate({required String tag, required Uint8List certificateData}) {
     return SecureEnclavePlatform.instance.storeCertificate(tag: tag, certificateData: certificateData);
   }
+
+  @override
+  Future<ResultModel<String?>> decryptWithAES({
+    required Uint8List encryptedData,
+    required Uint8List aesKey
+  }) {
+    return SecureEnclavePlatform.instance.decryptWithAES(
+      encryptedData: encryptedData,
+      aesKey: aesKey
+    );
+  }
 }

--- a/lib/secure_enclave_base.dart
+++ b/lib/secure_enclave_base.dart
@@ -145,4 +145,16 @@ abstract class SecureEnclaveBase {
     required String plainText,
     required String signature
   });
+
+  /// Decrypts the given encrypted data using AES algorithm with the provided key.
+  ///
+  /// The `encryptedData` parameter contains the encrypted payload (including IV as first 16 bytes).
+  /// The `aesKey` parameter is the AES key used for decryption.
+  ///
+  /// Returns a [ResultModel] containing the decrypted plain text as a `String`,
+  /// or `null` if decryption fails.
+  Future<ResultModel<String?>> decryptWithAES({
+    required Uint8List encryptedData,
+    required Uint8List aesKey
+  });
 }

--- a/lib/src/platform/secure_encalve_swift.dart
+++ b/lib/src/platform/secure_encalve_swift.dart
@@ -285,4 +285,25 @@ class SecureEnclaveSwift extends SecureEnclavePlatform {
       },
     );
   }
+
+  @override
+  Future<ResultModel<String?>> decryptWithAES({
+    required Uint8List encryptedData,
+    required Uint8List aesKey
+  }) async {
+    final result = await methodChannel.invokeMethod<dynamic>(
+      'decryptWithAES',
+      {
+        "encryptedData": encryptedData,
+        "aesKey": aesKey
+      },
+    );
+
+    return ResultModel.fromMap(
+      map: Map<String, dynamic>.from(result),
+      decoder: (rawData) {
+        return rawData as String?;
+      },
+    );
+  }
 }


### PR DESCRIPTION
- Add decryptWithAES method to EncryptionStrategy interface
- Implement AES/CBC/PKCS5Padding decryption for Android and iOS
- Support IV + encrypted data format (16 bytes IV + data)
- Add comprehensive AES decrypt test page with debug output
- Update RSA decrypt to return base64 encoded results
- Add enhanced error handling and validation
- Support both Modern and Legacy encryption strategies
- Add detailed documentation and troubleshooting guide

Breaking Changes:
- RSA decrypt now returns base64 encoded string instead of raw string
- New decryptWithAES method required for AES payload decryption

Features:
- IV extraction from first 16 bytes of encrypted data
- Proper AES/CBC decryption with PKCS7 padding
- Cross-platform support (Android/iOS)
- Comprehensive test interface with step-by-step debugging
- Automatic tag detection via DeviceInfoProvider
- Enhanced error messages with troubleshooting hints